### PR TITLE
update the organization profile with funding information

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,3 +1,5 @@
 # a11yhood
 
 organizing open information about assistive technologies.
+
+## funding


### PR DESCRIPTION
i've made a stub for our [organization's profile](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile) that appears for `github.com/a11yhood`.

![a preview of the current profile](https://github.com/user-attachments/assets/5154fdb4-6153-4e20-99ed-0df237230be2)

@jmankoff i feel like we could add our funding information there while we are building. could you suggest some text for a funding portion and we'll modify it in this PR.
